### PR TITLE
Add progress persistence and button locking

### DIFF
--- a/0-2.html
+++ b/0-2.html
@@ -102,6 +102,18 @@
       transform: translateY(2px);
       box-shadow: 0 2px #d1c7b7;
     }
+    .button-group button.disabled {
+      background: #eee;
+      color: #999;
+      cursor: default;
+      box-shadow: none;
+    }
+    .button-group button.done {
+      background: #c8c8c8;
+      color: #555;
+      cursor: default;
+      box-shadow: none;
+    }
     .circle-btn {
       position: absolute;
       bottom: 20px;

--- a/start.html
+++ b/start.html
@@ -102,6 +102,18 @@
       transform: translateY(2px);
       box-shadow: 0 2px #d1c7b7;
     }
+    .button-group button.disabled {
+      background: #eee;
+      color: #999;
+      cursor: default;
+      box-shadow: none;
+    }
+    .button-group button.done {
+      background: #c8c8c8;
+      color: #555;
+      cursor: default;
+      box-shadow: none;
+    }
     .circle-btn {
       position: absolute;
       bottom: 20px;


### PR DESCRIPTION
## Summary
- preserve `current` page after login by remembering stored state
- track progress index in Firebase
- introduce `setupStartPage` in `app.js` to manage `0-2` button states
- style disabled/completed buttons in `0-2.html` and `start.html`

## Testing
- `npm test` *(fails: could not find package.json)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68642b094a0c832e8e965eb7324df867